### PR TITLE
Github Action and fixed tests

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,17 @@
+name: Build
+on: [push, pull_request]
+jobs:
+  test:
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+        ruby: [2.6, 2.7]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v2
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: ${{ matrix.ruby }}
+          bundler-cache: true
+      - run: bundle exec rake

--- a/test/tiny_gltf_test.rb
+++ b/test/tiny_gltf_test.rb
@@ -59,7 +59,7 @@ class TinyGltfTest < Minitest::Test
   end
 
   def test_images
-    gltf = load_gltf('Avocado/glTF-Binary/Avocado.glb')
+    gltf = load_gltf('avocado/glTF-Binary/Avocado.glb')
     assert_equal gltf.buffer_views[0], gltf.images[0].buffer_view
     assert_equal gltf.images[0].size,  gltf.images[0].to_ptr.size
   end
@@ -135,7 +135,7 @@ class TinyGltfTest < Minitest::Test
     model = TinyGLTF::Model.new
     # 1px opaque white png #FFFFFF alpha 1.0
     assert_equal "\xff\xff\xff\xff".b, model.default_image.to_s
-    assert_equal "\xff\xff\xff\xff".b, model.default_image.to_ptr.to_s
+    assert_equal "\xff\xff\xff\xff".b, model.default_image.to_ptr.yield_self { |ptr| ptr.to_s(ptr.size) }
     assert_equal 'image/png',          model.default_image.mime_type
     assert_equal 1,                    model.default_image.width
     assert_equal 1,                    model.default_image.height


### PR DESCRIPTION
Added a Github action to run tests.

The tests were not passing on Ubuntu. So as a follow-up commit I've corrected them. There were two issues:

1. `test_images` was failing on case sensitive filesystems as the directory for the model is `avocado`, not `Avocado`.
2.  `test_default_image` was failing because calling `to_s` on a `Fiddle::Pointer` returns a C-style string i.e. will scan for a NULL byte and return a string leading up to this NULL byte, rather than a string matching the length of pointer's `size`.